### PR TITLE
Avoid caching problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ RUN chmod 0644 /etc/cron.d/hello-cron
 RUN touch /var/log/cron.log
 
 #Install Cron
-RUN apt-get update
-RUN apt-get -y install cron
-
+RUN apt-get -y update && apt-get -y install cron
 
 # Run the command on container startup
 CMD cron && tail -f /var/log/cron.log


### PR DESCRIPTION
`apt-get update` and `apt-get install` have to be executed at once, otherwise the update will be cached separately from the install which might cause caching issues (trying to install a package not available any more because update information is too old).

See [docker best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/apt-get).